### PR TITLE
Fix `declarationBundler` file filtering

### DIFF
--- a/disthelper/declarationbundler.js
+++ b/disthelper/declarationbundler.js
@@ -11,7 +11,7 @@ function getFiles(dir) {
   return Array.prototype.concat(...files);
 }
 
-const files = getFiles('./dist/declarations/src').filter((x) => !x.endsWith('x.d.ts'));
+const files = getFiles('./dist/declarations/src').filter((x) => x.split('/').pop() !== 'x.d.ts');
 
 for (const file of files) {
   fs.readFile(file, 'utf8', (err, data) => {


### PR DESCRIPTION
Using `endsWith('x.d.ts')` caused `getEditModeLatex.d.ts` and `getViewModeLatex.d.ts` to be filtered out

Fix: 
Use `filter((x) => x.split('/').pop() !== 'x.d.ts')`

Alternative Fix:
Use `filter((x) => !x.endsWith('/x.d.ts'))` (adding additional slash before `x.d.ts` )