### PR TITLE
Fix: Could not find a declaration file for module mathkeyboardengine

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,11 @@
   ],
   "version": "v1.1.0",
   "types": "./dist/MathKeyboardEngine.d.ts",
-  "main": "./dist/MathKeyboardEngine.cjs.js",
-  "module": "./dist/MathKeyboardEngine.es2017.mjs",
+  "main": "./dist/MathKeyboardEngine.es2017.cjs",
   "exports": {
     ".": {
       "types": "./dist/MathKeyboardEngine.d.ts",
-      "require": "./dist/MathKeyboardEngine.cjs.js",
+      "require": "./dist/MathKeyboardEngine.es2017.cjs",
       "import": "./dist/MathKeyboardEngine.es2017.mjs",
       "default": "./dist/MathKeyboardEngine.es2017.mjs"
     }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   ],
   "version": "v1.1.0",
   "types": "./dist/MathKeyboardEngine.d.ts",
+  "main": "./dist/MathKeyboardEngine.cjs.js",
+  "module": "./dist/MathKeyboardEngine.es2017.mjs",
   "exports": {
     ".": {
       "types": "./dist/MathKeyboardEngine.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
   "version": "v1.1.0",
   "types": "./dist/MathKeyboardEngine.d.ts",
   "exports": {
-    "node": {
+    ".": {
+      "types": "./dist/MathKeyboardEngine.d.ts",
+      "require": "./dist/MathKeyboardEngine.cjs.js",
       "import": "./dist/MathKeyboardEngine.es2017.mjs",
-      "require": "./dist/MathKeyboardEngine.es2017.cjs"
-    },
-    "default": "./dist/MathKeyboardEngine.es2017.mjs"
+      "default": "./dist/MathKeyboardEngine.es2017.mjs"
+    }
   },
   "files": [
     "dist/"


### PR DESCRIPTION
I ran into the same issue described in #9. For context, I am using this in a React application with Vite and Typescript.

```
Could not find a declaration file for module 'mathkeyboardengine'. '/path/to/node_modules/mathkeyboardengine/dist/MathKeyboardEngine.es2017.mjs' implicitly has an 'any' type.

There are types at '/path/to/node_modules/mathkeyboardengine/dist/MathKeyboardEngine.d.ts', but this result could not be resolved when respecting package.json "exports". The 'mathkeyboardengine' library may need to update its package.json or typings.
```

This fix should make it more flexible to import the library into different environments.

Thanks!